### PR TITLE
Update to version 1.1.2 and Paper 1.21.1

### DIFF
--- a/.run/Compile and start.run.xml
+++ b/.run/Compile and start.run.xml
@@ -10,7 +10,7 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </extension>
-    <option name="JAR_PATH" value="$PROJECT_DIR$/server/paper-1.20.6-150.jar" />
+    <option name="JAR_PATH" value="$PROJECT_DIR$/server/paper-1.21.1-128.jar" />
     <option name="PROGRAM_PARAMETERS" value="nogui" />
     <option name="WORKING_DIRECTORY" value="D:\Minecraft\Bonka\Mirage\server" />
     <option name="ALTERNATIVE_JRE_PATH" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The world tracking system also allows for runtime rollbacks without kicking play
 
 ---
 
-#### Version 1.1.1
+#### Version 1.1.2
 This version of Mirage contains:
 - Mirage world loading
 - Backup system
@@ -35,7 +35,7 @@ These are all the same world, just rendering as different mirage worlds! Using /
 <dependency>
     <groupId>gg.bonka</groupId>
     <artifactId>Mirage</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 </dependency>
 ```
 
@@ -117,8 +117,8 @@ void RenderWorldAs(Player player, World world, World visualizer) {
 
 ---
 
-## Server version Paper 1.20.6
-[Download directly here](https://api.papermc.io/v2/projects/paper/versions/1.20.6/builds/150/downloads/paper-1.20.6-150.jar)
+## Server version Paper 1.21.1
+[Download directly here](https://api.papermc.io/v2/projects/paper/versions/1.21.1/builds/128/downloads/paper-1.21.1-128.jar)
 or [Browse paper builds](https://papermc.io/downloads/all)
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gg.bonka</groupId>
   <artifactId>Mirage</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <packaging>jar</packaging>
 
   <name>Mirage</name>
@@ -113,7 +113,7 @@
       <dependency>
           <groupId>io.papermc.paper</groupId>
           <artifactId>paper-api</artifactId>
-          <version>1.20.6-R0.1-SNAPSHOT</version>
+          <version>1.21.1-R0.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
       <dependency>
@@ -136,7 +136,7 @@
       <dependency>
           <groupId>ca.bkaw</groupId>
           <artifactId>paper-nms</artifactId>
-          <version>1.20.6-SNAPSHOT</version>
+          <version>1.21.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
       <dependency>

--- a/src/main/java/gg/bonka/mirage/Mirage.java
+++ b/src/main/java/gg/bonka/mirage/Mirage.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 
 public final class Mirage extends JavaPlugin {
 
-    private final static String version = "1.1.0";
+    private final static String version = "1.1.2";
 
     @Getter
     private static Mirage instance;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Mirage
 version: '${project.version}'
 main: gg.bonka.mirage.Mirage
-api-version: '1.20.6'
+api-version: '1.21.1'
 load: STARTUP
 depend: [ProtocolLib]
 authors: [Stanley Dam @ Bonka Software]


### PR DESCRIPTION
Upgrade Mirage version to 1.1.2 and update the server dependency to Paper 1.21.1. This includes updates in documentation, build configuration, and plugin metadata.