### PR TITLE
Update to version 1.1.5 with improved block rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The world tracking system also allows for runtime rollbacks without kicking play
 
 ---
 
-#### Version 1.1.4
+#### Version 1.1.5
 This version of Mirage contains:
 - Mirage world loading
 - Backup system
@@ -35,7 +35,7 @@ These are all the same world, just rendering as different mirage worlds! Using /
 <dependency>
     <groupId>gg.bonka</groupId>
     <artifactId>Mirage</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gg.bonka</groupId>
   <artifactId>Mirage</artifactId>
-  <version>1.1.4</version>
+  <version>1.1.5</version>
   <packaging>jar</packaging>
 
   <name>Mirage</name>

--- a/src/main/java/gg/bonka/mirage/Mirage.java
+++ b/src/main/java/gg/bonka/mirage/Mirage.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 
 public final class Mirage extends JavaPlugin {
 
-    private final static String version = "1.1.4";
+    private final static String version = "1.1.5";
 
     @Getter
     private static Mirage instance;


### PR DESCRIPTION
Bumped version to 1.1.5 across documentation and pom.xml. Enhanced block interaction handling by checking for fake blocks to avoid conflicts with other plugins.