### PR TITLE
Update to version 1.1.7 and add world rendering events

### DIFF
--- a/.run/Compile and start.run.xml
+++ b/.run/Compile and start.run.xml
@@ -12,7 +12,7 @@
     </extension>
     <option name="JAR_PATH" value="$PROJECT_DIR$/server/paper-1.21.4-134.jar" />
     <option name="PROGRAM_PARAMETERS" value="nogui" />
-    <option name="WORKING_DIRECTORY" value="D:\Minecraft\Bonka\Mirage\server" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/server" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">
       <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="package" />

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The world tracking system also allows for runtime rollbacks without kicking play
 
 ---
 
-#### Version 1.1.6
+#### Version 1.1.7
 This version of Mirage contains:
 - Mirage world loading
 - Backup system
@@ -37,7 +37,7 @@ These are all the same world, just rendering as different mirage worlds! Using /
 <dependency>
     <groupId>gg.bonka</groupId>
     <artifactId>Mirage</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -117,6 +117,8 @@ void RenderWorldAs(Player player, World world, World visualizer) {
     ChunkRenderingSystem.getInstance().updateChunks(receiver);   
 }
 ```
+
+You can subscribe to the `StartPlayerWorldRenderingReloadEvent` & `FinishPlayerWorldRenderingReloadEvent` these are called when a player's world rendering changes.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>gg.bonka</groupId>
   <artifactId>Mirage</artifactId>
-  <version>1.1.6</version>
+  <version>1.1.7</version>
   <packaging>jar</packaging>
 
   <name>Mirage</name>

--- a/src/main/java/gg/bonka/mirage/chunks/ChunkRenderingSystem.java
+++ b/src/main/java/gg/bonka/mirage/chunks/ChunkRenderingSystem.java
@@ -8,6 +8,8 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.wrappers.BlockPosition;
 import com.comphenix.protocol.wrappers.WrappedBlockData;
 import gg.bonka.mirage.Mirage;
+import gg.bonka.mirage.chunks.events.FinishPlayerWorldRenderingReloadEvent;
+import gg.bonka.mirage.chunks.events.StartPlayerWorldRenderingReloadEvent;
 import gg.bonka.mirage.chunks.packets.ChunkPacket;
 import lombok.Getter;
 import org.bukkit.*;
@@ -87,8 +89,11 @@ public class ChunkRenderingSystem {
         Location location = player.getLocation();
         Optional<World> randomWorld = Bukkit.getWorlds().stream().filter(world -> world != player.getWorld()).findFirst();
 
+        new StartPlayerWorldRenderingReloadEvent(player).callEvent();
         randomWorld.ifPresent(world -> player.teleport(world.getSpawnLocation()));
+
         player.teleport(location);
+        new FinishPlayerWorldRenderingReloadEvent(player).callEvent();
     }
 
     /**

--- a/src/main/java/gg/bonka/mirage/chunks/events/FinishPlayerWorldRenderingReloadEvent.java
+++ b/src/main/java/gg/bonka/mirage/chunks/events/FinishPlayerWorldRenderingReloadEvent.java
@@ -1,0 +1,14 @@
+package gg.bonka.mirage.chunks.events;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Called when a player's world rendering is altered by Mirage.
+ * This event will be called after the world reload, use
+ * @see StartPlayerWorldRenderingReloadEvent when you want to do stuff pre reload.
+ */
+public class FinishPlayerWorldRenderingReloadEvent extends WorldRenderingEvent {
+    public FinishPlayerWorldRenderingReloadEvent(Player player) {
+        super(player);
+    }
+}

--- a/src/main/java/gg/bonka/mirage/chunks/events/StartPlayerWorldRenderingReloadEvent.java
+++ b/src/main/java/gg/bonka/mirage/chunks/events/StartPlayerWorldRenderingReloadEvent.java
@@ -1,0 +1,14 @@
+package gg.bonka.mirage.chunks.events;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Called when a player's world rendering is altered by Mirage.
+ * This event will be called at the start of the world reload, use
+ * @see FinishPlayerWorldRenderingReloadEvent when you want to do stuff after the reload.
+ */
+public class StartPlayerWorldRenderingReloadEvent extends WorldRenderingEvent {
+    public StartPlayerWorldRenderingReloadEvent(Player player) {
+        super(player);
+    }
+}

--- a/src/main/java/gg/bonka/mirage/chunks/events/WorldRenderingEvent.java
+++ b/src/main/java/gg/bonka/mirage/chunks/events/WorldRenderingEvent.java
@@ -1,0 +1,26 @@
+package gg.bonka.mirage.chunks.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+@AllArgsConstructor
+public abstract class WorldRenderingEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+}


### PR DESCRIPTION
This commit introduces `StartPlayerWorldRenderingReloadEvent` and `FinishPlayerWorldRenderingReloadEvent` for handling world rendering changes during reloads. It also updates the project to version 1.1.7 in documentation, `pom.xml`, and dependencies to reflect these new features. Minor adjustments in the run configuration are also made.